### PR TITLE
refactor(cli): replace untyped Store with typed credential stores

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,10 +6,35 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
+
+// FleetCredentials holds Mercedes-Benz Fleet API credentials (OAuth2 + Kafka).
+type FleetCredentials struct {
+	ClientID           string `json:"clientId"`
+	ClientSecret       string `json:"clientSecret"`
+	Region             string `json:"region"`
+	KafkaConsumerGroup string `json:"kafkaConsumerGroup"`
+	KafkaInputTopic    string `json:"kafkaInputTopic"`
+}
+
+// VehicleSpecCredentials holds Mercedes-Benz Vehicle Specification API credentials.
+type VehicleSpecCredentials struct {
+	APIKey string `json:"apiKey"`
+}
+
+// FleetCredentialStore reads and writes fleet credentials.
+type FleetCredentialStore interface {
+	Load() (*FleetCredentials, error)
+	Save(*FleetCredentials) error
+	Clear() error
+}
+
+// VehicleSpecCredentialStore reads and writes vehicle specification credentials.
+type VehicleSpecCredentialStore interface {
+	Load() (*VehicleSpecCredentials, error)
+	Save(*VehicleSpecCredentials) error
+	Clear() error
+}
 
 // Store reads and writes JSON-serializable data.
 type Store interface {
@@ -22,19 +47,19 @@ type Store interface {
 type Option func(*config)
 
 type config struct {
-	fleetCredentialStore       Store
-	vehicleSpecCredentialStore Store
+	fleetCredentialStore       FleetCredentialStore
+	vehicleSpecCredentialStore VehicleSpecCredentialStore
 	tokenStore                 Store
 	httpClient                 *http.Client
 }
 
 // WithFleetCredentialStore sets the credential store for Mercedes-Benz Fleet API (OAuth2 + Kafka).
-func WithFleetCredentialStore(s Store) Option {
+func WithFleetCredentialStore(s FleetCredentialStore) Option {
 	return func(c *config) { c.fleetCredentialStore = s }
 }
 
 // WithVehicleSpecCredentialStore sets the credential store for Mercedes-Benz Vehicle Specification API.
-func WithVehicleSpecCredentialStore(s Store) Option {
+func WithVehicleSpecCredentialStore(s VehicleSpecCredentialStore) Option {
 	return func(c *config) { c.vehicleSpecCredentialStore = s }
 }
 
@@ -48,8 +73,56 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *config) { c.httpClient = httpClient }
 }
 
-// FileStore is a file-backed store that uses protojson for proto messages
-// and encoding/json for other types.
+// fileStore is a generic file-backed credential store using encoding/json.
+type fileStore[T any] struct {
+	path string
+}
+
+// Load reads and unmarshals credentials from the file.
+func (s *fileStore[T]) Load() (*T, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return nil, fmt.Errorf("read store: %w", err)
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal store: %w", err)
+	}
+	return &v, nil
+}
+
+// Save marshals and writes credentials to the file.
+func (s *fileStore[T]) Save(v *T) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal store: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create store dir: %w", err)
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}
+
+// Clear removes the file.
+func (s *fileStore[T]) Clear() error {
+	err := os.Remove(s.path)
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// NewFleetCredentialFileStore creates a file-backed store for fleet credentials.
+func NewFleetCredentialFileStore(path string) FleetCredentialStore {
+	return &fileStore[FleetCredentials]{path: path}
+}
+
+// NewVehicleSpecCredentialFileStore creates a file-backed store for vehicle spec credentials.
+func NewVehicleSpecCredentialFileStore(path string) VehicleSpecCredentialStore {
+	return &fileStore[VehicleSpecCredentials]{path: path}
+}
+
+// FileStore is a file-backed store that uses encoding/json.
 type FileStore struct {
 	path string
 }
@@ -60,17 +133,10 @@ func NewFileStore(path string) *FileStore {
 }
 
 // Read unmarshals the file contents into target.
-// If target implements [proto.Message], protojson is used for unmarshaling.
 func (s *FileStore) Read(target any) error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {
 		return fmt.Errorf("read store: %w", err)
-	}
-	if msg, ok := target.(proto.Message); ok {
-		if err := protojson.Unmarshal(data, msg); err != nil {
-			return fmt.Errorf("unmarshal store: %w", err)
-		}
-		return nil
 	}
 	if err := json.Unmarshal(data, target); err != nil {
 		return fmt.Errorf("unmarshal store: %w", err)
@@ -79,24 +145,10 @@ func (s *FileStore) Read(target any) error {
 }
 
 // Write marshals data and writes it to the file.
-// If data implements [proto.Message], protojson is used for marshaling.
 func (s *FileStore) Write(data any) error {
-	var bytes []byte
-	if msg, ok := data.(proto.Message); ok {
-		var err error
-		bytes, err = protojson.MarshalOptions{
-			Multiline: true,
-			Indent:    "  ",
-		}.Marshal(msg)
-		if err != nil {
-			return fmt.Errorf("marshal store: %w", err)
-		}
-	} else {
-		var err error
-		bytes, err = json.MarshalIndent(data, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal store: %w", err)
-		}
+	bytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal store: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
 		return fmt.Errorf("create store dir: %w", err)

--- a/cli/command.go
+++ b/cli/command.go
@@ -18,8 +18,6 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
 	"github.com/way-platform/mbz-go"
 	"github.com/way-platform/mbz-go/api/vehiclesv1"
-	fleetcreds "github.com/way-platform/mbz-go/proto/gen/go/wayplatform/connect/mercedesbenz/fleet/v1"
-	vspeccreds "github.com/way-platform/mbz-go/proto/gen/go/wayplatform/connect/mercedesbenz/vehiclespec/v1"
 	"golang.org/x/oauth2"
 	"golang.org/x/term"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -94,52 +92,54 @@ func newLoginFleetCommand(cfg *config) *cobra.Command {
 	clientID := cmd.Flags().String("client-id", "", "OAuth2 client ID")
 	clientSecret := cmd.Flags().String("client-secret", "", "OAuth2 client secret")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		creds := &fleetcreds.Credentials{}
+		creds := &FleetCredentials{}
 		if cfg.fleetCredentialStore != nil {
-			if err := cfg.fleetCredentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			if loaded, err := cfg.fleetCredentialStore.Load(); err == nil {
+				creds = loaded
+			} else if !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
 			}
 		}
 		// Override with flags.
 		if *region != "" {
-			creds.SetRegion(*region)
+			creds.Region = *region
 		}
 		if *clientID != "" {
-			creds.SetClientId(*clientID)
+			creds.ClientID = *clientID
 		}
 		if *clientSecret != "" {
-			creds.SetClientSecret(*clientSecret)
+			creds.ClientSecret = *clientSecret
 		}
 		// Default region.
-		if creds.GetRegion() == "" {
-			creds.SetRegion(string(mbz.RegionECE))
+		if creds.Region == "" {
+			creds.Region = string(mbz.RegionECE)
 		}
 		// Prompt for missing fields.
-		if creds.GetClientId() == "" {
+		if creds.ClientID == "" {
 			val, err := promptSecret(cmd, "Enter OAuth2 client ID: ")
 			if err != nil {
 				return err
 			}
-			creds.SetClientId(val)
+			creds.ClientID = val
 		}
-		if creds.GetClientSecret() == "" {
+		if creds.ClientSecret == "" {
 			val, err := promptSecret(cmd, "Enter OAuth2 client secret: ")
 			if err != nil {
 				return err
 			}
-			creds.SetClientSecret(val)
+			creds.ClientSecret = val
 		}
 		// Persist credentials.
 		if cfg.fleetCredentialStore != nil {
-			if err := cfg.fleetCredentialStore.Write(creds); err != nil {
+			if err := cfg.fleetCredentialStore.Save(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
 		// Run OAuth2 flow.
 		oauth2Config, err := mbz.NewOAuth2Config(
-			mbz.Region(creds.GetRegion()),
-			creds.GetClientId(),
-			creds.GetClientSecret(),
+			mbz.Region(creds.Region),
+			creds.ClientID,
+			creds.ClientSecret,
 		)
 		if err != nil {
 			return err
@@ -153,7 +153,7 @@ func newLoginFleetCommand(cfg *config) *cobra.Command {
 				return fmt.Errorf("write token: %w", err)
 			}
 		}
-		cmd.Printf("Logged in to %s.\n", creds.GetRegion())
+		cmd.Printf("Logged in to %s.\n", creds.Region)
 		return nil
 	}
 	return cmd
@@ -166,24 +166,26 @@ func newLoginVehicleSpecCommand(cfg *config) *cobra.Command {
 	}
 	apiKey := cmd.Flags().String("api-key", "", "API key")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		creds := &vspeccreds.Credentials{}
+		creds := &VehicleSpecCredentials{}
 		if cfg.vehicleSpecCredentialStore != nil {
-			if err := cfg.vehicleSpecCredentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			if loaded, err := cfg.vehicleSpecCredentialStore.Load(); err == nil {
+				creds = loaded
+			} else if !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
 			}
 		}
 		if *apiKey != "" {
-			creds.SetApiKey(*apiKey)
+			creds.APIKey = *apiKey
 		}
-		if creds.GetApiKey() == "" {
+		if creds.APIKey == "" {
 			val, err := promptSecret(cmd, "Enter API key: ")
 			if err != nil {
 				return err
 			}
-			creds.SetApiKey(val)
+			creds.APIKey = val
 		}
 		if cfg.vehicleSpecCredentialStore != nil {
-			if err := cfg.vehicleSpecCredentialStore.Write(creds); err != nil {
+			if err := cfg.vehicleSpecCredentialStore.Save(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
@@ -611,14 +613,9 @@ func newConsumeVehicleSignalsCommand(cfg *config) *cobra.Command {
 	enableDebug := cmd.Flags().Bool("debug", false, "Enable debug logging")
 	format := cmd.Flags().String("format", "json", "Format to use for output")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		creds := &fleetcreds.Credentials{}
-		if cfg.fleetCredentialStore != nil {
-			if err := cfg.fleetCredentialStore.Read(creds); err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return fmt.Errorf("no credentials found, please login using `mbz auth login fleet`")
-				}
-				return fmt.Errorf("read credentials: %w", err)
-			}
+		creds, err := resolveFleetCredentials(cfg)
+		if err != nil {
+			return err
 		}
 		var token oauth2.Token
 		if cfg.tokenStore != nil {
@@ -634,14 +631,14 @@ func newConsumeVehicleSignalsCommand(cfg *config) *cobra.Command {
 			return err
 		}
 		// Resolve topic and consumer group from credentials, with flag overrides.
-		topic := creds.GetKafkaInputTopic()
+		topic := creds.KafkaInputTopic
 		if *topicFlag != "" {
 			topic = *topicFlag
 		}
 		if topic == "" {
 			return fmt.Errorf("topic is required: set via --topic or store in fleet credentials")
 		}
-		consumerGroup := creds.GetKafkaConsumerGroup()
+		consumerGroup := creds.KafkaConsumerGroup
 		if *consumerGroupFlag != "" {
 			consumerGroup = *consumerGroupFlag
 		}
@@ -657,7 +654,7 @@ func newConsumeVehicleSignalsCommand(cfg *config) *cobra.Command {
 		case mbz.RegionAMAPNA:
 			bootstrapServer = mbz.KafkaBootstrapServerAMAPNA
 		default:
-			return fmt.Errorf("invalid region: %s", creds.GetRegion())
+			return fmt.Errorf("invalid region: %s", creds.Region)
 		}
 		opts := []kgo.Opt{
 			kgo.DialTLS(),
@@ -729,12 +726,40 @@ func newConsumeVehicleSignalsCommand(cfg *config) *cobra.Command {
 
 // Client constructors.
 
-func newOAuth2Client(cmd *cobra.Command, cfg *config) (*mbz.Client, error) {
-	creds := &fleetcreds.Credentials{}
-	if cfg.fleetCredentialStore != nil {
-		if err := cfg.fleetCredentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("read credentials: %w", err)
+func resolveFleetCredentials(cfg *config) (*FleetCredentials, error) {
+	if cfg.fleetCredentialStore == nil {
+		return nil, fmt.Errorf("no fleet credentials configured")
+	}
+	creds, err := cfg.fleetCredentialStore.Load()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("no credentials found, please login using `mbz auth login fleet`")
 		}
+		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+	return creds, nil
+}
+
+func resolveVehicleSpecCredentials(cfg *config) (*VehicleSpecCredentials, error) {
+	if cfg.vehicleSpecCredentialStore == nil {
+		return nil, fmt.Errorf("no vehicle spec credentials configured")
+	}
+	creds, err := cfg.vehicleSpecCredentialStore.Load()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"no credentials found, please login using `mbz auth login vehicle-spec --api-key <key>`",
+			)
+		}
+		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+	return creds, nil
+}
+
+func newOAuth2Client(cmd *cobra.Command, cfg *config) (*mbz.Client, error) {
+	creds, err := resolveFleetCredentials(cfg)
+	if err != nil {
+		return nil, err
 	}
 	var token oauth2.Token
 	if cfg.tokenStore != nil {
@@ -763,24 +788,17 @@ func newOAuth2Client(cmd *cobra.Command, cfg *config) (*mbz.Client, error) {
 }
 
 func newClientWithAPIKey(cmd *cobra.Command, cfg *config) (*mbz.Client, error) {
-	creds := &vspeccreds.Credentials{}
-	if cfg.vehicleSpecCredentialStore != nil {
-		if err := cfg.vehicleSpecCredentialStore.Read(creds); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, fmt.Errorf(
-					"no credentials found, please login using `mbz auth login vehicle-spec --api-key <key>`",
-				)
-			}
-			return nil, fmt.Errorf("read credentials: %w", err)
-		}
+	creds, err := resolveVehicleSpecCredentials(cfg)
+	if err != nil {
+		return nil, err
 	}
-	if creds.GetApiKey() == "" {
+	if creds.APIKey == "" {
 		return nil, fmt.Errorf(
 			"no API key found, please login using `mbz auth login vehicle-spec --api-key <key>`",
 		)
 	}
 	opts := []mbz.ClientOption{
-		mbz.WithAPIKey(creds.GetApiKey()),
+		mbz.WithAPIKey(creds.APIKey),
 	}
 	if cfg.httpClient != nil {
 		opts = append(opts, mbz.WithHTTPClient(cfg.httpClient))
@@ -800,9 +818,9 @@ func promptSecret(cmd *cobra.Command, prompt string) (string, error) {
 	return string(input), nil
 }
 
-func resolveOAuth2Region(creds *fleetcreds.Credentials, token oauth2.Token) (mbz.Region, error) {
-	if creds.GetRegion() != "" {
-		return mbz.Region(creds.GetRegion()), nil
+func resolveOAuth2Region(creds *FleetCredentials, token oauth2.Token) (mbz.Region, error) {
+	if creds.Region != "" {
+		return mbz.Region(creds.Region), nil
 	}
 	return inferRegionFromAccessToken(token.AccessToken)
 }

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 
 	"github.com/way-platform/mbz-go"
-	fleetcreds "github.com/way-platform/mbz-go/proto/gen/go/wayplatform/connect/mercedesbenz/fleet/v1"
 	"golang.org/x/oauth2"
 )
 
 func TestResolveOAuth2RegionUsesStoredRegionFirst(t *testing.T) {
 	t.Parallel()
 
-	creds := &fleetcreds.Credentials{}
-	creds.SetRegion(string(mbz.RegionAMAPNA))
+	creds := &FleetCredentials{
+		Region: string(mbz.RegionAMAPNA),
+	}
 	region, err := resolveOAuth2Region(
 		creds,
 		oauth2.Token{AccessToken: testJWT("https://ssoalpha.dvb.corpinter.net/v1")},
@@ -43,7 +43,7 @@ func TestResolveOAuth2RegionInfersFromTokenIssuer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			region, err := resolveOAuth2Region(&fleetcreds.Credentials{}, oauth2.Token{
+			region, err := resolveOAuth2Region(&FleetCredentials{}, oauth2.Token{
 				AccessToken: testJWT(tt.iss),
 			})
 			if err != nil {

--- a/cmd/mbz/main.go
+++ b/cmd/mbz/main.go
@@ -19,8 +19,8 @@ func main() {
 	tokenPath, _ := xdg.ConfigFile("mbz-go/token.json")
 	var debug bool
 	cmd := cli.NewCommand(
-		cli.WithFleetCredentialStore(cli.NewFileStore(fleetCredPath)),
-		cli.WithVehicleSpecCredentialStore(cli.NewFileStore(vspecCredPath)),
+		cli.WithFleetCredentialStore(cli.NewFleetCredentialFileStore(fleetCredPath)),
+		cli.WithVehicleSpecCredentialStore(cli.NewVehicleSpecCredentialFileStore(vspecCredPath)),
 		cli.WithTokenStore(cli.NewFileStore(tokenPath)),
 		cli.WithHTTPClient(&http.Client{
 			Transport: &mbz.DebugTransport{Enabled: &debug},


### PR DESCRIPTION
## Summary

- Replace `Store` interface for credentials with typed `FleetCredentialStore` and `VehicleSpecCredentialStore` interfaces
- Add private generic `fileStore[T]` with typed constructors
- Remove credential provider functions — store is the single injection point
- Simplify resolve functions to single-path logic
- Simplify `FileStore` to json-only (remove proto.Message branching)
- Keep untyped `Store`/`FileStore` for token store (orthogonal)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`