### PR TITLE
refactor: use connect error codes instead of custom ResponseError type

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,193 @@
+package mbz
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/way-platform/mbz-go/api/vehiclesv1"
+	fleetv1 "github.com/way-platform/mbz-go/proto/gen/go/wayplatform/connect/mercedesbenz/fleet/v1"
+	"golang.org/x/oauth2"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	client := &Client{
+		baseURL: srv.URL + "/api",
+		config: clientConfig{
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			retryCount:  0,
+			timeout:     0,
+		},
+	}
+	return client
+}
+
+func TestListVehicles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/accounts/vehicles" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("expected Bearer test-token, got %s", got)
+		}
+		vehicles := []vehiclesv1.Vehicle{
+			{VIN: "WDB1234567890001"},
+			{VIN: "WDB1234567890002"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(vehicles)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t, srv)
+	resp, err := client.ListVehicles(context.Background(), &fleetv1.ListVehiclesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(resp.GetVehicles()); got != 2 {
+		t.Fatalf("expected 2 vehicles, got %d", got)
+	}
+	if got := resp.GetVehicles()[0].GetVin(); got != "WDB1234567890001" {
+		t.Errorf("expected WDB1234567890001, got %s", got)
+	}
+	if got := resp.GetVehicles()[1].GetVin(); got != "WDB1234567890002" {
+		t.Errorf("expected WDB1234567890002, got %s", got)
+	}
+}
+
+func TestAssignVehicles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/accounts/vehicles" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body []vehiclesv1.Vehicle
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if len(body) != 2 {
+			t.Fatalf("expected 2 vehicles in body, got %d", len(body))
+		}
+		if body[0].VIN != "VIN1" || body[1].VIN != "VIN2" {
+			t.Errorf("unexpected VINs: %+v", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t, srv)
+	req := &fleetv1.AssignVehiclesRequest{}
+	req.SetVins([]string{"VIN1", "VIN2"})
+	_, err := client.AssignVehicles(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteVehicles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/accounts/vehicles" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body []vehiclesv1.Vehicle
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if len(body) != 1 || body[0].VIN != "VIN_TO_DELETE" {
+			t.Errorf("unexpected body: %+v", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t, srv)
+	req := &fleetv1.DeleteVehiclesRequest{}
+	req.SetVins([]string{"VIN_TO_DELETE"})
+	_, err := client.DeleteVehicles(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResponseError_ConnectCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   connect.Code
+	}{
+		{"bad request", http.StatusBadRequest, connect.CodeInvalidArgument},
+		{"unauthorized", http.StatusUnauthorized, connect.CodeUnauthenticated},
+		{"forbidden", http.StatusForbidden, connect.CodePermissionDenied},
+		{"not found", http.StatusNotFound, connect.CodeNotFound},
+		{"conflict", http.StatusConflict, connect.CodeAlreadyExists},
+		{"too many requests", http.StatusTooManyRequests, connect.CodeResourceExhausted},
+		{"internal server error", http.StatusInternalServerError, connect.CodeInternal},
+		{"service unavailable", http.StatusServiceUnavailable, connect.CodeUnavailable},
+		{"gateway timeout", http.StatusGatewayTimeout, connect.CodeDeadlineExceeded},
+		{"unknown status", http.StatusTeapot, connect.CodeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte("error body"))
+			}))
+			t.Cleanup(srv.Close)
+
+			client := newTestClient(t, srv)
+			_, err := client.ListVehicles(context.Background(), &fleetv1.ListVehiclesRequest{})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				t.Fatalf("expected connect.Error, got %T: %v", err, err)
+			}
+			if connectErr.Code() != tt.wantCode {
+				t.Errorf("expected code %v, got %v", tt.wantCode, connectErr.Code())
+			}
+		})
+	}
+}
+
+func TestResponseError_ErrorsAs(t *testing.T) {
+	// Verify that consumers using errors.As(err, &ResponseError{}) still works
+	// after wrapping in connect.NewError.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"vehicle not found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t, srv)
+	_, err := client.ListVehicles(context.Background(), &fleetv1.ListVehiclesRequest{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var respErr *ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected errors.As to find *ResponseError, got %T: %v", err, err)
+	}
+	if respErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", respErr.StatusCode)
+	}
+	if string(respErr.Body) != `{"error":"vehicle not found"}` {
+		t.Errorf("unexpected body: %s", string(respErr.Body))
+	}
+}

--- a/error.go
+++ b/error.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"connectrpc.com/connect"
 )
 
-// ResponseError represents a VW Fleet Interface response error.
+// ResponseError represents a Mercedes-Benz API response error.
 type ResponseError struct {
 	// StatusCode is the HTTP status code of the response.
 	StatusCode int
@@ -19,10 +21,11 @@ func newResponseError(httpResponse *http.Response) error {
 	if err != nil {
 		body = fmt.Appendf(nil, "failed to read response body: %s", err)
 	}
-	return &ResponseError{
+	respErr := &ResponseError{
 		StatusCode: httpResponse.StatusCode,
 		Body:       body,
 	}
+	return respErr.connectError()
 }
 
 // Error implements the error interface.
@@ -31,4 +34,35 @@ func (e *ResponseError) Error() string {
 		return fmt.Sprintf("http %d: %s", e.StatusCode, string(e.Body))
 	}
 	return fmt.Sprintf("http %d", e.StatusCode)
+}
+
+func (e *ResponseError) connectError() error {
+	return connect.NewError(httpStatusToConnectCode(e.StatusCode), e)
+}
+
+func httpStatusToConnectCode(statusCode int) connect.Code {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return connect.CodeInvalidArgument
+	case http.StatusUnauthorized:
+		return connect.CodeUnauthenticated
+	case http.StatusForbidden:
+		return connect.CodePermissionDenied
+	case http.StatusNotFound:
+		return connect.CodeNotFound
+	case http.StatusConflict:
+		return connect.CodeAlreadyExists
+	case http.StatusTooManyRequests:
+		return connect.CodeResourceExhausted
+	case http.StatusNotImplemented:
+		return connect.CodeUnimplemented
+	case http.StatusServiceUnavailable:
+		return connect.CodeUnavailable
+	case http.StatusGatewayTimeout:
+		return connect.CodeDeadlineExceeded
+	case http.StatusInternalServerError:
+		return connect.CodeInternal
+	default:
+		return connect.CodeUnknown
+	}
 }


### PR DESCRIPTION
## Summary

- Wrap `ResponseError` in `connect.NewError()` via `connectError()` method (preserves `errors.As`)
- Add HTTP-level `client_test.go` with `httptest.NewServer` coverage
- Tests verify ListVehicles, AssignVehicles, DeleteVehicles, error code mapping, and `errors.As` compatibility

## Motivation

Aligns with SDK conformance standard: consumers get standard Connect error codes. The `ResponseError` struct is preserved because `backend/` consumers use `errors.As(err, &respErr)` for status-code-specific handling.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `errors.As(err, &mbz.ResponseError{})` still works through connect wrapper
- [x] backend/ builds cleanly (verified locally against monorepo)