### PR TITLE
refactor: remove ResponseError struct, use plain connect errors

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -164,30 +164,3 @@ func TestResponseError_ConnectCode(t *testing.T) {
 		})
 	}
 }
-
-func TestResponseError_ErrorsAs(t *testing.T) {
-	// Verify that consumers using errors.As(err, &ResponseError{}) still works
-	// after wrapping in connect.NewError.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"vehicle not found"}`))
-	}))
-	t.Cleanup(srv.Close)
-
-	client := newTestClient(t, srv)
-	_, err := client.ListVehicles(context.Background(), &fleetv1.ListVehiclesRequest{})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	var respErr *ResponseError
-	if !errors.As(err, &respErr) {
-		t.Fatalf("expected errors.As to find *ResponseError, got %T: %v", err, err)
-	}
-	if respErr.StatusCode != http.StatusNotFound {
-		t.Errorf("expected status 404, got %d", respErr.StatusCode)
-	}
-	if string(respErr.Body) != `{"error":"vehicle not found"}` {
-		t.Errorf("unexpected body: %s", string(respErr.Body))
-	}
-}

--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package mbz
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,36 +9,18 @@ import (
 	"connectrpc.com/connect"
 )
 
-// ResponseError represents a Mercedes-Benz API response error.
-type ResponseError struct {
-	// StatusCode is the HTTP status code of the response.
-	StatusCode int
-	// Body is the body of the response.
-	Body []byte
-}
-
 func newResponseError(httpResponse *http.Response) error {
 	body, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		body = fmt.Appendf(nil, "failed to read response body: %s", err)
 	}
-	respErr := &ResponseError{
-		StatusCode: httpResponse.StatusCode,
-		Body:       body,
+	var msg string
+	if len(body) > 0 {
+		msg = fmt.Sprintf("http %d: %s", httpResponse.StatusCode, body)
+	} else {
+		msg = fmt.Sprintf("http %d", httpResponse.StatusCode)
 	}
-	return respErr.connectError()
-}
-
-// Error implements the error interface.
-func (e *ResponseError) Error() string {
-	if len(e.Body) > 0 {
-		return fmt.Sprintf("http %d: %s", e.StatusCode, string(e.Body))
-	}
-	return fmt.Sprintf("http %d", e.StatusCode)
-}
-
-func (e *ResponseError) connectError() error {
-	return connect.NewError(httpStatusToConnectCode(e.StatusCode), e)
+	return connect.NewError(httpStatusToConnectCode(httpResponse.StatusCode), errors.New(msg))
 }
 
 func httpStatusToConnectCode(statusCode int) connect.Code {


### PR DESCRIPTION
## Summary

- Remove exported `ResponseError` type (breaking change)
- Switch to simple pattern: `connect.NewError` with message string
- Consumers should use `connect.CodeOf(err)` instead of `errors.As`

## Motivation

Follow-up to #38. The `ResponseError` struct was preserved for backwards compatibility, but all consumers in backend/ only need the connect code (they check `StatusCode == 404` etc., which maps directly to `connect.CodeNotFound`). Removing the struct simplifies the API surface and enforces uniform error handling.

## Breaking change

Consumers using `errors.As(err, &mbzgo.ResponseError{})` must switch to `connect.CodeOf(err)`. The backend/ changes will be made in the monorepo once this is released.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes