### PR TITLE
fix(signal): validate integer bounds before int32 conversion

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -67,7 +67,7 @@ func (s *Signal) AsProto() (*mbzv1.Signal, error) {
 	case mbzv1.SignalType_STRING:
 		result.SetStringValue(s.Value)
 	case mbzv1.SignalType_INTEGER:
-		intValue, err := strconv.Atoi(s.Value)
+		intValue, err := strconv.ParseInt(s.Value, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse integer value for signal %s: %w", s.Name, err)
 		}


### PR DESCRIPTION
## Summary

- Replace `strconv.Atoi` + unchecked `int32()` cast with `strconv.ParseInt(s.Value, 10, 32)`
- `ParseInt` with bitSize=32 returns a range error if the value exceeds int32 bounds, preventing silent truncation/sign-flip

Fixes security scanner finding: "Downcasting or changing sign of an integer with int32 method"

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Values within int32 range parse correctly (existing behavior unchanged)
- [ ] Values exceeding int32 range now return a clear parse error instead of silent truncation